### PR TITLE
Fix logging helper for dash-only messages

### DIFF
--- a/GoodCheck.cmd
+++ b/GoodCheck.cmd
@@ -707,16 +707,16 @@ exit /b
 :WriteToConsoleAndToLog
 SetLocal EnableDelayedExpansion
 set "message=%*"
-if "!message!"=="" (
-	echo.
-	if defined logFile (
-		echo.>>"!logFile!"
-	)
+if not defined message (
+        echo.
+        if defined logFile (
+                >>"!logFile!" echo.
+        )
 ) else (
-	echo !message!
-	if defined logFile (
-		echo !message!>>"!logFile!"
-	)
+        echo(!message!
+        if defined logFile (
+                >>"!logFile!" echo(!message!
+        )
 )
 EndLocal
 exit /b
@@ -724,14 +724,14 @@ exit /b
 :WriteToLog
 SetLocal EnableDelayedExpansion
 set "message=%*"
-if "!message!"=="" (
-	if defined logFile (
-		echo.>>"!logFile!"
-	)
+if not defined message (
+        if defined logFile (
+                >>"!logFile!" echo.
+        )
 ) else (
-	if defined logFile (
-		echo !message!>>"!logFile!"
-	)
+        if defined logFile (
+                >>"!logFile!" echo(!message!
+        )
 )
 EndLocal
 exit /b


### PR DESCRIPTION
## Summary
- ensure WriteToConsoleAndToLog handles separator lines and empty messages without syntax errors
- adjust WriteToLog to mirror the safer echo behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f90396ff5c8331afafa3838a1d4d65