### PR TITLE
Handle exclamation marks in GoodCheck working directory

### DIFF
--- a/GoodCheck.cmd
+++ b/GoodCheck.cmd
@@ -5,7 +5,11 @@ chcp 1251
 title GoodCheck
 cls
 
-SetLocal EnableDelayedExpansion
+SetLocal EnableExtensions DisableDelayedExpansion
+
+set "goodCheckFolder=%~dp0"
+
+SetLocal EnableExtensions EnableDelayedExpansion
 
 
 ::==============================CONFIG================================
@@ -54,7 +58,6 @@ set "zapretServiceName=winws1"
 ::Consts
 set "version=v1.3.07"
 
-set "goodCheckFolder=%~dp0"
 
 (set nl=^
 %emptyline%

--- a/Start.cmd
+++ b/Start.cmd
@@ -1,3 +1,3 @@
 chcp 1251
 cd /d "%~dp0"
-wscript elevator.vbs cmd /c "%~dp0Config.cmd"
+wscript elevator.vbs "%~dp0Config.cmd"

--- a/elevator.vbs
+++ b/elevator.vbs
@@ -3,8 +3,10 @@ If args.count = 0 Then
     wscript.echo "elevate.vbs <executable> <parameters>"
 Else
     Set UAC = CreateObject("Shell.Application")
+    Set fso = CreateObject("Scripting.FileSystemObject")
     cmd = args(0)
     param = ""
+    dir = ""
     
     If args.count >= 2 Then
         param = Chr(34) & args(1) & Chr(34)
@@ -13,5 +15,13 @@ Else
         Next
     End If
     
-    UAC.ShellExecute cmd, param, "", "runas", 1
+    On Error Resume Next
+    If fso.FileExists(cmd) Then
+        dir = fso.GetParentFolderName(fso.GetAbsolutePathName(cmd))
+    ElseIf fso.FolderExists(cmd) Then
+        dir = fso.GetAbsolutePathName(cmd)
+    End If
+    On Error GoTo 0
+
+    UAC.ShellExecute cmd, param, dir, "runas", 1
 End If


### PR DESCRIPTION
## Summary
- initialize GoodCheck.cmd in a delayed-expansion disabled scope so the script directory is captured verbatim
- re-enable delayed expansion after persisting the working directory to avoid truncating paths that contain exclamation marks

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f9b7e5a7e883319bc93d35d0b782bb