### PR TITLE
Fix blank logging calls without empty argument

### DIFF
--- a/GoodCheck.cmd
+++ b/GoodCheck.cmd
@@ -772,7 +772,11 @@ exit /b
 
 :WriteToConsoleAndToLog
 SetLocal EnableDelayedExpansion
-set "message=%*"
+if "%~1"=="" (
+        set "message="
+) else (
+        set "message=%*"
+)
 if not defined message (
         echo.
         if defined logFile (


### PR DESCRIPTION
## Summary
- call WriteToConsoleAndToLog without an explicit empty argument so Windows command parsing finds the label correctly
- retain the logging helper for blank lines so they still reach the log file

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f9c5c788188331bf60bd5d8a93ce3e