### PR TITLE
Handle empty strategy lists before running tests

### DIFF
--- a/GoodCheck.cmd
+++ b/GoodCheck.cmd
@@ -435,6 +435,32 @@ call :WriteToConsoleAndToLog ""
 
 
 ::====================================================================
+::Validating parsed strategies
+set "strategiesCount=!strategiesNum!"
+if not defined strategiesCount (
+        set endedWithErrors=2
+        call :WriteToConsoleAndToLog ""
+        call :WriteToConsoleAndToLog ERROR: No strategies were parsed from "!strategiesList!".
+        goto EOF
+)
+set "_invalidStrategiesCount="
+for /F "delims=0123456789-" %%s in ("!strategiesCount!") do set "_invalidStrategiesCount=%%s"
+if defined _invalidStrategiesCount (
+        set endedWithErrors=2
+        call :WriteToConsoleAndToLog ""
+        call :WriteToConsoleAndToLog ERROR: Invalid strategy counter value "!strategiesCount!" for "!strategiesList!".
+        goto EOF
+)
+if !strategiesCount! LSS 0 (
+        set endedWithErrors=2
+        call :WriteToConsoleAndToLog ""
+        call :WriteToConsoleAndToLog ERROR: Strategy list "!strategiesList!" does not contain runnable entries.
+        goto EOF
+)
+set "_invalidStrategiesCount="
+
+
+::====================================================================
 ::Preparing TCP 16-20 DPI detection test suite
 cls
 


### PR DESCRIPTION
## Summary
- validate the parsed strategy count before running the DPI checks
- stop execution early with clear errors when no runnable strategies are found

## Testing
- not run (Windows batch script)


------
https://chatgpt.com/codex/tasks/task_e_68f9c95532148331b672c47fc870177b