### PR TITLE
Handle missing curl path during connectivity check

### DIFF
--- a/GoodCheck.cmd
+++ b/GoodCheck.cmd
@@ -281,6 +281,12 @@ if not "!ERRORLEVEL!"=="0" (
 )
 
 ::Checking up network connectivity
+if "!curl!"=="" (
+        set endedWithErrors=2
+        call :WriteToConsoleAndToLog ""
+        call :WriteToConsoleAndToLog ERROR: Can't perform network connectivity check because Curl path is empty
+        goto EOF
+)
 call :WriteToConsoleAndToLog Checking up network connectivity...
 ::Apparently ICMP is blocked for some people, so we'll use curl here
 rem ping -n 1 -w 2000 "!netConnTestURL!">NUL


### PR DESCRIPTION
## Summary
- prevent the connectivity check from running when the curl path variable is empty
- surface a clear error message and stop the script instead of invoking an empty command

## Testing
- no automated tests were run (batch script change)


------
https://chatgpt.com/codex/tasks/task_e_68fa08fed20083318221e99ca7cb354c