### PR TITLE
Handle empty log messages without echo off

### DIFF
--- a/GoodCheck.cmd
+++ b/GoodCheck.cmd
@@ -133,9 +133,17 @@ rem ============================================================================
 setlocal DisableDelayedExpansion
 set "message=%~1"
 if defined LOG_FILE (
-    >>"%LOG_FILE%" echo %message%
+    if "%~1"=="" (
+        >>"%LOG_FILE%" echo.
+    ) else (
+        >>"%LOG_FILE%" echo %message%
+    )
 )
-echo %message%
+if "%~1"=="" (
+    echo.
+) else (
+    echo %message%
+)
 endlocal & exit /b 0
 
 rem ============================================================================


### PR DESCRIPTION
## Summary
- ensure the logging helper writes blank lines without triggering the default "ECHO is off" output
- mirror this handling for console output so empty log entries show as actual blank lines

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa3f697b748331a11adc95c081e187