### PR TITLE
Fix logging of curl version output with parentheses

### DIFF
--- a/GoodCheck.cmd
+++ b/GoodCheck.cmd
@@ -185,7 +185,13 @@ if not defined curl (
     exit /b 1
 )
 for /f "usebackq tokens=*" %%V in (`"%curl%" -V 2^>NUL`) do (
-    call :Log "curl: %%V"
+    set "line=%%V"
+    setlocal EnableDelayedExpansion
+    set "safeLine=!line:^=^^!"
+    set "safeLine=!safeLine:^(=^(!"
+    set "safeLine=!safeLine:^)=^)!"
+    call :Log "curl: !safeLine!"
+    endlocal
 )
 exit /b 0
 


### PR DESCRIPTION
## Summary
- escape special characters from `curl -V` output before logging so parentheses in the version string do not break the batch script

## Testing
- not run (batch script change)


------
https://chatgpt.com/codex/tasks/task_e_68fa404151788331b00f1c12b186680a