### PR TITLE
Handle curl -V output when logging

### DIFF
--- a/GoodCheck.cmd
+++ b/GoodCheck.cmd
@@ -186,7 +186,10 @@ if not defined curl (
     call :Log "ERROR: curl executable not found."
     exit /b 1
 )
-for /f "usebackq delims=" %%L in (`"%curl%" -V 2^>NUL`) do call :Log "curl: %%L"
+for /f "usebackq delims=" %%L in (`"%curl%" -V 2^>NUL`) do (
+    if defined LOG_FILE >>"%LOG_FILE%" echo(curl: %%L
+    echo(curl: %%L
+)
 exit /b 0
 
 rem ============================================================================


### PR DESCRIPTION
## Summary
- prevent the curl version logging loop from choking on parentheses in the reported version string by writing through echo(

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb9bb516508331b469bfae8fc4fa4c