### PR TITLE
Handle GoodCheck network pre-check failure gracefully

### DIFF
--- a/GoodCheck.cmd
+++ b/GoodCheck.cmd
@@ -199,8 +199,11 @@ if errorlevel 1 (
     call :Log "WARNING: HTTPS connectivity failed, retrying with --insecure."
     "%curl%" --silent --show-error --max-time %curlMinTimeout% --insecure --output NUL "%netConnTestURL%" >NUL 2>&1
     if errorlevel 1 (
-        call :Log "ERROR: network connectivity test failed."
-        exit /b 1
+        call :Log "WARNING: network connectivity test failed; continuing without pre-check."
+        call :Log "WARNING: HTTP checks may report DETECTED/FAIL until connectivity issues are resolved."
+        set "NETWORK_WARNING=1"
+        if !exitCode! LSS 1 set "exitCode=1"
+        exit /b 0
     )
     set "curlExtraKeys=%curlExtraKeys% --insecure"
 )


### PR DESCRIPTION
## Summary
- allow GoodCheck to continue running even when the initial HTTPS connectivity probe fails
- record the connectivity issue as a warning so the final summary reflects the degraded state

## Testing
- not run (Windows batch script cannot be executed in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68fba9e7fa388331abf7b995d89d51ed