### PR TITLE
Fix strategy loader quoting

### DIFF
--- a/GoodCheck.cmd
+++ b/GoodCheck.cmd
@@ -308,8 +308,9 @@ if not defined strategiesList (
 set "strategiesCount=-1"
 set "strategyExtraKeys="
 set "strategyCurlExtraKeys="
-for /f "usebackq tokens=*" %%L in ("%strategiesList%") do (
-    set "line=%%L"
+for /f "usebackq delims=" %%L in ("%strategiesList%") do (
+    set "line="
+    set line=%%L
     if not defined line goto NEXT_STRAT
     if "!line!"=="" goto NEXT_STRAT
     if "!line:~0,1!"=="/" goto NEXT_STRAT


### PR DESCRIPTION
## Summary
- allow strategy loader to read lines containing quotes without breaking the batch loop

## Testing
- not run (Windows batch script)


------
https://chatgpt.com/codex/tasks/task_e_68fc4459d1148331acf03570e5600247